### PR TITLE
Refactor to remove parameter checking with every action

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Redux middleware to execute a callback on action types using a whitelist or blac
 
 ## Usage
 
-Both the whitelist and blacklist methods expect two parameters: 
+Both the whitelist and blacklist methods expect two parameters:
 
 1. `Actions` (*array*) array of action types (*string*) to check against
 2. `callback` (*function*)
@@ -25,7 +25,7 @@ Note: recommended to move the middleware creation into a separate file
 ```
 import { createStore, combineReducers, applyMiddleware, compose } from 'redux'
 import * as reducers from '../reducers'
-import wb from 'redux-white-black'
+import * as wb from 'redux-white-black'
 import {
   CREATE_SHORTLIST,
   EDIT_SHORTLIST,

--- a/package.json
+++ b/package.json
@@ -7,10 +7,12 @@
     "build": "rm -rf lib && babel src -d lib",
     "prepublish": "npm run build",
     "start": "npm run build",
-    "test": "npm run build && mocha test/ --recursive --compilers js:babel-core/register"
+    "test": "mocha test/ --recursive --compilers js:babel-register"
   },
   "babel": {
-    "presets": ["es2015"]
+    "presets": [
+      "es2015"
+    ]
   },
   "keywords": [
     "redux",
@@ -27,6 +29,7 @@
   "devDependencies": {
     "babel-cli": "^6.7.7",
     "babel-preset-es2015": "^6.6.0",
+    "babel-register": "^6.23.0",
     "chai": "^3.5.0",
     "mocha": "^2.4.5",
     "redux": "^3.5.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,48 +1,44 @@
-export const blacklist = (blacklistActions, callback) => {
-  return store => next => action => {
-    const result = next(action)
+const callbackOnPredicate = (predicate, callback) =>
+  store => next => action => {
+    const result = next(action);
 
+    if (predicate(action.type)) {
+      callback(action, store);
+    }
+
+    return result;
+  };
+
+export const blacklist = (blacklistActions, callback) => {
+  if (process.env.NODE_ENV !== 'production') {
     if (!Array.isArray(blacklistActions)) {
-      console.error('blacklist middleware expected array as first argument:', blacklistActions)
-      return result
+      throw new Error('blacklist middleware expected array as first argument');
     }
 
     if (typeof callback !== 'function') {
-      console.error('blacklist middleware expected function as callback:', callback)
-      return result
+      throw new Error('blacklist middleware expected function as callback');
     }
-
-    if (blacklistActions.indexOf(action.type) === -1) {
-      callback(action, store)
-    }
-
-    return result
   }
-}
+
+  return callbackOnPredicate(
+    type => blacklistActions.indexOf(type) === -1,
+    callback
+  );
+};
 
 export const whitelist = (whitelistActions, callback) => {
-  return store => next => action => {
-    const result = next(action)
-
+  if (process.env.NODE_ENV !== 'production') {
     if (!Array.isArray(whitelistActions)) {
-      console.error('whitelist middleware expected array as first argument:', whitelistActions)
-      return result
+      throw new Error('whitelist middleware expected array as first argument');
     }
 
     if (typeof callback !== 'function') {
-      console.error('whitelist middleware expected function as callback:', callback)
-      return result
+      throw new Error('whitelist middleware expected function as callback');
     }
-
-    if (whitelistActions.indexOf(action.type) !== -1) {
-      callback(action, store)
-    }
-
-    return result
   }
-}
 
-export default {
-  blacklist: blacklist,
-  whitelist: whitelist,
-}
+  return callbackOnPredicate(
+    type => whitelistActions.indexOf(type) !== -1,
+    callback
+  );
+};

--- a/test/blacklist.js
+++ b/test/blacklist.js
@@ -1,7 +1,7 @@
 import {expect} from 'chai'
 import sinon  from "sinon"
 import {createStore, applyMiddleware} from 'redux'
-import wb from "../lib"
+import { blacklist } from '../src';
 
 describe("Blacklist", () => {
 
@@ -11,8 +11,8 @@ describe("Blacklist", () => {
   beforeEach(() => {
     callback = sinon.spy()
 
-    const blacklist = wb.blacklist(['ACTION_1', 'ACTION_2'], callback)
-    const createStoreWithMiddleware = applyMiddleware(blacklist)(createStore)
+    const blacklistMiddleware = blacklist(['ACTION_1', 'ACTION_2'], callback)
+    const createStoreWithMiddleware = applyMiddleware(blacklistMiddleware)(createStore)
 
     const initialState = { active: false }
     const reducer = (state = initialState, action) => {

--- a/test/exports.js
+++ b/test/exports.js
@@ -1,7 +1,7 @@
 import {expect} from 'chai'
 import sinon  from "sinon"
 import {createStore, applyMiddleware} from 'redux'
-import {whitelist, blacklist} from "../lib"
+import {whitelist, blacklist} from "../src"
 
 describe("Exports", () => {
   it("should be able to export the two methods individually", () => {

--- a/test/whitelist.js
+++ b/test/whitelist.js
@@ -1,7 +1,7 @@
 import {expect} from 'chai'
 import sinon  from "sinon"
 import {createStore, applyMiddleware} from 'redux'
-import wb from "../lib"
+import {whitelist} from "../src"
 
 describe("Whitelist", () => {
 
@@ -11,8 +11,8 @@ describe("Whitelist", () => {
   beforeEach(() => {
     callback = sinon.spy()
 
-    const whitelist = wb.whitelist(['ACTION_1', 'ACTION_2'], callback)
-    const createStoreWithMiddleware = applyMiddleware(whitelist)(createStore)
+    const whitelistMiddleware = whitelist(['ACTION_1', 'ACTION_2'], callback)
+    const createStoreWithMiddleware = applyMiddleware(whitelistMiddleware)(createStore)
 
     const initialState = { active: false }
     const reducer = (state = initialState, action) => {


### PR DESCRIPTION
- [x] `whitelist` and `blacklist` now use the same internal function and pass a predicate
- [x] Array of actions and the callback are only checked once when `whitelist` or `blacklist` are first created instead of every time an action passes through
- [x] Place above behind a `process.env.NODE_ENV !== 'production'` check so that they'll be removed in production
- [x] Run tests against `src` instead of `lib` so that a build each time is not needed
- [x] Remove default export as you can just do `import * as wb from 'redux-white-black'` instead (can add the `export default` back in if you want as it's a breaking change)

The main thing I wanted to try and change was the checking of arguments each time an action goes through but I'm afraid I got a bit carried away and did a lot more 😛 